### PR TITLE
NEW_LINE constant instead of 'BLANK_LINE' string

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Takes four parameters and prints a list of elements vertically with a title (opt
 
 Alignment of elements and title could be optionally altered using the `TextAlignment` enum.
 
-**Note:** Blank lines can be added between elements by using the `"BLANK_LINE"` keyword. For more details, take a look at [example 4.1](#example-41).
+**Note:** Blank lines can be added between elements by using the `CLIPrintTool.NEW_LINE` constant. To see how it's used, refer to [example 4.1](#example-41).
 
 ### Parameters
 <table>
@@ -327,9 +327,9 @@ CLIPrintTool().list(["System Information", "Crash Reports", "Exit"], "MAIN MENU"
 #### Example 4.1
 Prints a list of elements vertically with title and left-aligned.
 
-**Note:** The `"BLANK_LINE"` keyword was added inside our list of menu options to display a blank line.
+**Note:** The `CLIPrintTool.NEW_LINE` constant was added inside our list of menu options to display a blank line.
 ```python
-menu_options = ["System Information", "Crash Reports", "BLANK_LINE", "Exit"]
+menu_options = ["System Information", "Crash Reports", CLIPrintTool.NEW_LINE, "Exit"]
 CLIPrintTool().list(menu_options, "MAIN MENU")
 ```
 ![Screenshot of the console output from the example above.](./img/list-example-4-1.png)

--- a/cli-print-tool/cli_print_tool.py
+++ b/cli-print-tool/cli_print_tool.py
@@ -23,6 +23,9 @@ class TextAlignment(Enum):
 
 
 class CLIPrintTool:
+
+    NEW_LINE = "NEW_LINE"
+
     # Constructor
     def __init__(self, max_line_length=100):
         self.__max_length = max_line_length  # print statements longer than this value will be wrapped automatically
@@ -201,7 +204,7 @@ class CLIPrintTool:
 
         index = 1
         for element in elements:
-            if element == "BLANK_LINE":
+            if element == self.NEW_LINE:
                 # print empty line
                 self.__print_box_content("", elements_alignment)
             else:


### PR DESCRIPTION
## Current Situation
Currently, `'BLANK_LINE'` string is used as a representation value for printing an empty string `''` as a list element (so it's replaceable by any other string value)

And the user has to have prior knowledge to type the exact value of `'BLANK_LINE'` to use it properly, so they can mistype and not having this feature working as desired.

## Proposition
I figured it's more beneficial if we replace that by a public class constant `NEW_LINE` so users can easily access and don't have to remember the exact blank line string value.

## Usage
1. Before: `'BLANK_LINE'`
2. After: `CLIPrintTool.NEW_LINE`